### PR TITLE
Changes implementation for IGuiHelper#drawColoredLine

### DIFF
--- a/1.11/src/main/java/net/voxelindustry/brokkgui/wrapper/GuiHelper.java
+++ b/1.11/src/main/java/net/voxelindustry/brokkgui/wrapper/GuiHelper.java
@@ -264,7 +264,7 @@ public class GuiHelper implements IGuiHelper
         this.enableAlpha();
         GlStateManager.color(c.getRed(), c.getGreen(), c.getBlue(), (float) (c.getAlpha() * alphaMask));
 
-        renderer.beginDrawing(EGuiRenderMode.LINE, false);
+        renderer.beginDrawing(EGuiRenderMode.LINES, false);
         GL11.glLineWidth(lineWeight);
 
         renderer.addVertex(startX, startY, zLevel);

--- a/1.11/src/main/java/net/voxelindustry/brokkgui/wrapper/GuiRenderer.java
+++ b/1.11/src/main/java/net/voxelindustry/brokkgui/wrapper/GuiRenderer.java
@@ -103,8 +103,8 @@ public class GuiRenderer implements IGuiRenderer
         {
             case QUADS:
                 return GL11.GL_QUADS;
-            case LINE:
-                return GL11.GL_LINE;
+            case LINE_STRIP:
+                return GL11.GL_LINE_STRIP;
             case LINES:
                 return GL11.GL_LINES;
             case POINTS:

--- a/1.12/src/main/java/net/voxelindustry/brokkgui/wrapper/GuiHelper.java
+++ b/1.12/src/main/java/net/voxelindustry/brokkgui/wrapper/GuiHelper.java
@@ -264,7 +264,7 @@ public class GuiHelper implements IGuiHelper
         this.enableAlpha();
         GlStateManager.color(c.getRed(), c.getGreen(), c.getBlue(), (float) (c.getAlpha() * alphaMask));
 
-        renderer.beginDrawing(EGuiRenderMode.LINE, false);
+        renderer.beginDrawing(EGuiRenderMode.LINES, false);
         GL11.glLineWidth(lineWeight);
 
         renderer.addVertex(startX, startY, zLevel);

--- a/1.12/src/main/java/net/voxelindustry/brokkgui/wrapper/GuiRenderer.java
+++ b/1.12/src/main/java/net/voxelindustry/brokkgui/wrapper/GuiRenderer.java
@@ -103,8 +103,8 @@ public class GuiRenderer implements IGuiRenderer
         {
             case QUADS:
                 return GL11.GL_QUADS;
-            case LINE:
-                return GL11.GL_LINE;
+            case LINE_STRIP:
+                return GL11.GL_LINE_STRIP;
             case LINES:
                 return GL11.GL_LINES;
             case POINTS:

--- a/core/src/main/java/net/voxelindustry/brokkgui/internal/EGuiRenderMode.java
+++ b/core/src/main/java/net/voxelindustry/brokkgui/internal/EGuiRenderMode.java
@@ -5,5 +5,5 @@ package net.voxelindustry.brokkgui.internal;
  */
 public enum EGuiRenderMode
 {
-    POINTS, LINE, LINES, QUADS, TRIANGLES, TRIANGLES_STRIP;
+    POINTS, LINE_STRIP, LINES, QUADS, TRIANGLES, TRIANGLES_STRIP;
 }

--- a/fabric-1.14/src/main/java/net/voxelindustry/brokkgui/wrapper/GuiHelper.java
+++ b/fabric-1.14/src/main/java/net/voxelindustry/brokkgui/wrapper/GuiHelper.java
@@ -266,7 +266,7 @@ public class GuiHelper implements IGuiHelper
         this.enableAlpha();
         GlStateManager.color4f(c.getRed(), c.getGreen(), c.getBlue(), (float) (c.getAlpha() * alphaMask));
 
-        renderer.beginDrawing(EGuiRenderMode.LINE, false);
+        renderer.beginDrawing(EGuiRenderMode.LINES, false);
         GL11.glLineWidth(lineWeight);
 
         renderer.addVertex(startX, startY, zLevel);

--- a/fabric-1.14/src/main/java/net/voxelindustry/brokkgui/wrapper/GuiRenderer.java
+++ b/fabric-1.14/src/main/java/net/voxelindustry/brokkgui/wrapper/GuiRenderer.java
@@ -103,8 +103,8 @@ public class GuiRenderer implements IGuiRenderer
         {
             case QUADS:
                 return GL11.GL_QUADS;
-            case LINE:
-                return GL11.GL_LINE;
+            case LINE_STRIP:
+                return GL11.GL_LINE_STRIP;
             case LINES:
                 return GL11.GL_LINES;
             case POINTS:


### PR DESCRIPTION
Fixes #12 
The old implementation was using ``EGuiRenderMode#LINE`` to draw a line, it refers to ``GL11.GL_LINE`` which isn't a valid enum for ``glBegin``.
The new implementation changes ``EGuiRenderMode#LINE`` enum to ``EGuiRenderMode#LINE_STRIP`` (to allow line stripping), it now also refers to ``GL11.GL_LINE_STRIP`` and changes ``IGuiHelper#drawColoredLine`` implementation to use ``EGuiRenderMode#LINES`` which refers to ``GL11.GL_LINES`` and is a valid enum for ``glBegin``.